### PR TITLE
[codex] restore Raven maintenance baseline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,36 @@
+name: Maven verification
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Java ${{ matrix.java-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - "11"
+          - "26"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+
+      - name: Verify Maven build
+        run: mvn --batch-mode clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-jdk: openjdk11
-script:
-- echo "skipping tests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Raven is restarting maintenance after a dormant period. Small, reviewable
+changes with clear verification are the most useful contributions during this
+phase.
+
+## Before Starting
+
+Open an issue for changes that affect service boundaries, dependency versions,
+database migrations, or deployment behavior. Describe the problem, expected
+behavior, and affected modules.
+
+Do not include passwords, tokens, private endpoints, or exploit details in
+public issues. For a potential vulnerability, open an issue requesting a
+private reporting channel without disclosing the sensitive details.
+
+## Development Workflow
+
+1. Create a focused branch.
+2. Keep each commit limited to one maintenance concern.
+3. Add or update tests when behavior changes.
+4. Run the Maven verification build:
+
+```bash
+mvn clean verify
+```
+
+5. Include the verification result and any remaining limitations in the pull
+   request description.
+
+## Pull Requests
+
+Pull requests should explain:
+
+- What changed
+- Why the change is needed
+- Which modules are affected
+- How the change was verified
+- Whether runtime configuration or deployment steps changed
+
+Large dependency upgrades should be split into compatible stages and discussed
+in an issue before implementation.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,68 @@
+# Maintenance
+
+## Current Status
+
+Raven resumed maintenance in June 2026 after a dormant period. The first
+maintenance milestone is a reviewable baseline: accurate public documentation,
+safer local tooling, a reproducible Maven build, focused regression tests, and
+real continuous integration.
+
+The project is not currently presented as production-ready. Existing
+deployments should review configuration and rotate credentials before running
+the services.
+
+## Runtime Dependencies
+
+The full service topology depends on:
+
+- MySQL for application and group records
+- Redis for routing and conversation state
+- Kafka for message delivery
+- Nacos for configuration
+- ZooKeeper for service discovery
+- FastDFS for file uploads
+
+Unit and build verification should remain independent of those external
+services. Integration coverage for these boundaries is follow-up work.
+
+## Security Notes
+
+The historical migration `flyway/sql/V5__insert_original_app_config.sql`
+contains a bootstrap app secret. It is public repository history, not a
+production credential. Rotate it in every deployed environment.
+
+The local Flyway helper reads database settings from environment variables:
+
+| Variable | Default |
+| --- | --- |
+| `MYSQL_HOST` | `127.0.0.1` |
+| `MYSQL_PORT` | `3306` |
+| `MYSQL_DATABASE` | `imdb` |
+| `MYSQL_USER` | `root` |
+| `MYSQL_PASSWORD` | empty |
+
+Do not commit deployment credentials, local passwords, or generated secrets.
+
+## Modernization Roadmap
+
+### Baseline
+
+- Remove stale public demo information.
+- Remove committed local database passwords.
+- Restore clean compilation on modern JDKs.
+- Repair known result-contract regressions.
+- Run Maven verification in GitHub Actions.
+
+### Next
+
+- Upgrade Spring Boot and Spring Cloud in compatible stages.
+- Audit bundled Flyway command-line JARs and JDBC drivers.
+- Replace the historical bootstrap-secret flow.
+- Add integration tests for external service boundaries.
+- Define release, security-reporting, and issue-triage processes.
+
+## Support Policy
+
+Until a compatibility matrix is published, changes should preserve existing
+runtime behavior unless a pull request clearly documents a migration. Open an
+issue before starting broad dependency or architecture changes.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,79 @@
-# raven
+# Raven
 
-Open Source Instant Message System. 
-It provides a solution that communicate between different platforms, such as Ios, Android and Web. It includes:
+Raven is an open-source instant messaging server built with Spring Boot and
+Spring Cloud. It provides backend services for mobile and web clients,
+including gateway access, message routing, group management, storage helpers,
+and file upload support.
 
-|  Repo   | Description  | Comment |
-|  ----  | ----  | ----  |
-| [Mobile Client](https://github.com/bbpatience/raven-client) | IOS and Android client |  by flutter |
-| [Web Client](https://github.com/bbpatience/raven-web) | Web Client| by Angular |
-| [App Server](https://github.com/bbpatience/raven-appserver) | Application Server deal with group and contacts things | by Spring boot |
-| [IM Server](https://github.com/IamNotShady/raven) | IM Server | by Spring Cloud|
+## Maintenance Status
 
+Maintenance resumed in June 2026 after a dormant period. The current work is
+focused on restoring a reproducible build, removing stale public setup
+information, and defining a staged modernization path.
 
-### Architecture
+Raven is not currently presented as production-ready. The service architecture
+depends on external infrastructure and the dependency stack still needs
+incremental upgrades. See [MAINTENANCE.md](MAINTENANCE.md) for the active scope
+and known limitations.
 
-![avatar](doc/DesignDoc/image/Infrastructure.png)
+## Modules
 
+| Module | Responsibility |
+| --- | --- |
+| `raven-admin` | Application configuration, gateway discovery, and group management APIs |
+| `raven-common` | Shared models, protocol definitions, Netty helpers, and utilities |
+| `raven-file` | FastDFS-backed file upload service |
+| `raven-gateway` | Client-facing gateway and message producer |
+| `raven-route` | Kafka-backed message routing and notifications |
+| `raven-storage` | Redis-backed routing and conversation storage helpers |
+| `raven-test` | Manual client and pressure-test utilities |
 
-### Document
+## Architecture
 
-* Work flow
-([Click Me](doc/DesignDoc/doc/process.md))
-* Pressure Test Result
-([Click Me](doc/PressureTestRecord/doc/2019.6.2-record.md)) 
+![Raven architecture](doc/DesignDoc/image/Infrastructure.png)
 
-### Demo
+The original message-flow notes remain available in
+[doc/DesignDoc/doc/process.md](doc/DesignDoc/doc/process.md).
 
-Demo: https://114.67.79.183     http://114.67.79.183
+## Infrastructure
 
+Running the complete service stack requires:
 
+- MySQL
+- Redis
+- Kafka
+- Nacos
+- ZooKeeper
+- FastDFS for file uploads
+
+The Maven verification build does not require these services:
+
+```bash
+mvn clean verify
 ```
-Test Account1:  13800222222, password: 222222
-Test Account2:  13800333333, password: 333333
-```
 
-### Screen Shot
+## Related Clients
+
+| Repository | Description | Technology |
+| --- | --- | --- |
+| [raven-client](https://github.com/bbpatience/raven-client) | iOS and Android client | Flutter |
+| [raven-web](https://github.com/bbpatience/raven-web) | Web client | Angular |
+| [raven-appserver](https://github.com/bbpatience/raven-appserver) | Application server for groups and contacts | Spring Boot |
+
+## Historical Screenshots
+
 <div>
-<img src="doc/Images/conversation.jpeg" height="330" width="190" >
-<img src="doc/Images/chat1.png" height="330" width="190" >
-<img src="doc/Images/chat2.jpeg" height="330" width="190" >
-<img src="doc/Images/web.jpg" height="330" width="190" >
+<img src="doc/Images/conversation.jpeg" height="330" width="190">
+<img src="doc/Images/chat1.png" height="330" width="190">
+<img src="doc/Images/chat2.jpeg" height="330" width="190">
+<img src="doc/Images/web.jpg" height="330" width="190">
 </div>
 
-### Contact us
-* zhou.xiaoxiao@outlook.com
-* bbpatience@gmail.com
+## Contributing
 
-#### QQ Group chat
-<div>
-<img src="doc/Images/RavenQRCode.png" height="330" width="190" >
-</div>
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Keep
+changes focused and include verification results.
+
+## License
+
+Raven is licensed under the [GNU General Public License v3.0](LICENSE).

--- a/docs/superpowers/plans/2026-06-01-maintenance-restart.md
+++ b/docs/superpowers/plans/2026-06-01-maintenance-restart.md
@@ -1,0 +1,327 @@
+# Raven Maintenance Restart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore an honest, secure, reproducible maintenance baseline for the dormant Raven repository and publish it as a reviewable pull request.
+
+**Architecture:** Keep the existing Spring Boot and Spring Cloud application architecture intact. Make narrowly scoped changes at the repository boundary: contributor documentation, local Flyway tooling, parent Maven build configuration, one admin-service contract fix with regression tests, and GitHub Actions verification.
+
+**Tech Stack:** Java 8 source compatibility, Maven, Spring Boot 2.1, Lombok, JUnit 4, Mockito, Flyway command-line tooling, GitHub Actions
+
+---
+
+### Task 1: Publish The Maintenance Restart Scope
+
+**Files:**
+- Modify: `README.md`
+- Create: `MAINTENANCE.md`
+- Create: `CONTRIBUTING.md`
+- Create: `docs/superpowers/plans/2026-06-01-maintenance-restart.md`
+
+- [ ] **Step 1: Rewrite the README status and contributor entry points**
+
+State that maintenance is resuming after a dormant period. Remove the stale
+demo endpoint, public test accounts, and deleted pressure-test link. Add module
+overview, infrastructure prerequisites, `mvn clean verify`, and links to
+`MAINTENANCE.md` and `CONTRIBUTING.md`.
+
+- [ ] **Step 2: Add maintenance and contribution guidance**
+
+Document the baseline scope, known infrastructure requirements, staged
+dependency modernization, historical seed-secret rotation requirement, issue
+triage expectations, and pull-request verification command.
+
+- [ ] **Step 3: Verify documentation cleanup**
+
+Run:
+
+```bash
+rg -n '114\.67\.79\.183|13800222222|13800333333|2019\.6\.2-record' README.md MAINTENANCE.md CONTRIBUTING.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md MAINTENANCE.md CONTRIBUTING.md docs/superpowers/plans/2026-06-01-maintenance-restart.md
+git commit -m "docs: define maintenance restart scope"
+```
+
+### Task 2: Remove Committed Local Database Passwords
+
+**Files:**
+- Modify: `flyway/conf/flyway.conf`
+- Modify: `flyway/migrate.sh`
+- Modify: `flyway/flyway`
+
+- [ ] **Step 1: Make local migration settings environment-driven**
+
+Remove `flyway.password = 123456`. Update `migrate.sh` to read:
+
+```bash
+MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-imdb}"
+MYSQL_USER="${MYSQL_USER:-root}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+```
+
+Build MySQL and Flyway argument arrays so a password argument is passed only
+when `MYSQL_PASSWORD` is non-empty. Resolve the Flyway wrapper relative to the
+script path so the helper works outside the `flyway/` directory.
+
+- [ ] **Step 2: Remove the invalid wrapper character**
+
+Delete the standalone non-ASCII character between Flyway wrapper Java
+selection and classpath setup.
+
+- [ ] **Step 3: Verify shell syntax and password removal**
+
+Run:
+
+```bash
+bash -n flyway/migrate.sh flyway/flyway
+rg -n '123456|-p123456|flyway\.password\s*=' flyway/conf/flyway.conf flyway/migrate.sh
+```
+
+Expected: shell syntax passes and the search returns no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add flyway/conf/flyway.conf flyway/migrate.sh flyway/flyway
+git commit -m "security: remove committed local database password"
+```
+
+### Task 3: Restore Clean Compilation On Modern JDKs
+
+**Files:**
+- Modify: `pom.xml`
+- Modify: `raven-admin/pom.xml`
+- Modify: `raven-file/pom.xml`
+- Modify: `raven-gateway/pom.xml`
+- Modify: `raven-route/pom.xml`
+
+- [ ] **Step 1: Configure modern Lombok annotation processing**
+
+Add:
+
+```xml
+<lombok.version>1.18.46</lombok.version>
+```
+
+Configure `maven-compiler-plugin` in the parent build:
+
+```xml
+<annotationProcessorPaths>
+    <path>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+    </path>
+</annotationProcessorPaths>
+```
+
+- [ ] **Step 2: Fix Docker image tag configuration**
+
+Replace each accidental `<tag>latest</tag>n` with `<tag>latest</tag>` in the
+route, gateway, admin, and file-service POM files.
+
+- [ ] **Step 3: Verify common-module clean compilation**
+
+Run:
+
+```bash
+mvn clean test -pl raven-common -am
+```
+
+Expected: four existing common-module tests pass on JDK 26.
+
+- [ ] **Step 4: Confirm the remaining admin contract failure**
+
+Run:
+
+```bash
+mvn clean test
+```
+
+Expected: compilation reaches `raven-admin` and fails because
+`GroupServiceImpl.joinGroup` and `GroupServiceImpl.quitGroup` return
+`ResultCode` while the interface requires `Result`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pom.xml raven-admin/pom.xml raven-file/pom.xml raven-gateway/pom.xml raven-route/pom.xml
+git commit -m "build: restore clean compilation on modern JDKs"
+```
+
+### Task 4: Repair Group Membership Result Contracts
+
+**Files:**
+- Modify: `raven-admin/src/main/java/com/raven/admin/group/service/impl/GroupServiceImpl.java`
+- Create: `raven-admin/src/test/java/com/raven/admin/group/service/impl/GroupServiceImplTest.java`
+
+- [ ] **Step 1: Write the failing empty-member-list regression test**
+
+Create:
+
+```java
+@Test
+public void joinGroupRejectsEmptyMemberList() {
+    GroupReqParam param = new GroupReqParam();
+    param.setMembers(Collections.emptyList());
+
+    Result result = service.joinGroup(param);
+
+    assertEquals(ResultCode.COMMON_INVALID_PARAMETER.getCode(), result.getCode().intValue());
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+mvn -pl raven-admin -am test
+```
+
+Expected: compilation fails because the implementation still returns
+`ResultCode`.
+
+- [ ] **Step 3: Implement the minimal result-contract fix**
+
+Change both method signatures to `Result` and replace the empty-list returns
+with:
+
+```java
+return Result.failure(ResultCode.COMMON_INVALID_PARAMETER);
+```
+
+- [ ] **Step 4: Write the failing missing-member error-code regression test**
+
+Add:
+
+```java
+@Test
+public void quitGroupReportsMissingMember() {
+    GroupReqParam param = new GroupReqParam();
+    param.setGroupId("group-id");
+    param.setMembers(Collections.singletonList("missing-member"));
+    when(groupValidator.isValid("group-id")).thenReturn(true);
+    when(memberNotValidator.isValid("group-id", param.getMembers())).thenReturn(false);
+
+    Result result = service.quitGroup(param);
+
+    assertEquals(ResultCode.GROUP_ERROR_MEMBER_NOT_IN.getCode(), result.getCode().intValue());
+}
+```
+
+- [ ] **Step 5: Run the test to verify the error-code assertion fails**
+
+Run:
+
+```bash
+mvn -pl raven-admin -am test
+```
+
+Expected: `quitGroupReportsMissingMember` fails because the implementation
+returns the group validator error code.
+
+- [ ] **Step 6: Use the member validator error code**
+
+Replace:
+
+```java
+return Result.failure(groupValidator.errorCode());
+```
+
+inside the failed `memberNotValidator` branch with:
+
+```java
+return Result.failure(memberNotValidator.errorCode());
+```
+
+- [ ] **Step 7: Verify admin and reactor tests**
+
+Run:
+
+```bash
+mvn clean test
+```
+
+Expected: all reactor modules compile and all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add raven-admin/src/main/java/com/raven/admin/group/service/impl/GroupServiceImpl.java raven-admin/src/test/java/com/raven/admin/group/service/impl/GroupServiceImplTest.java
+git commit -m "fix(admin): align group membership service results"
+```
+
+### Task 5: Enable GitHub Actions Verification
+
+**Files:**
+- Delete: `.travis.yml`
+- Create: `.github/workflows/maven.yml`
+
+- [ ] **Step 1: Replace placeholder Travis configuration**
+
+Create a GitHub Actions workflow using `actions/checkout@v6` and
+`actions/setup-java@v5`. Grant `contents: read`, enable Maven caching, and run
+`mvn --batch-mode clean verify` for Java 11 and Java 26.
+
+- [ ] **Step 2: Verify local Maven build**
+
+Run:
+
+```bash
+mvn clean verify
+```
+
+Expected: all reactor modules compile, package, and pass tests on local JDK 26.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/maven.yml .travis.yml
+git commit -m "ci: run Maven verification with GitHub Actions"
+```
+
+### Task 6: Publish The Pull Request
+
+**Files:**
+- Inspect: all files changed since `origin/master`
+
+- [ ] **Step 1: Inspect the final branch**
+
+Run:
+
+```bash
+git diff --check origin/master...HEAD
+git status --short --branch
+git log --oneline origin/master..HEAD
+```
+
+Expected: no whitespace errors, clean working tree, and reviewable commits.
+
+- [ ] **Step 2: Push the maintenance branch**
+
+Run:
+
+```bash
+git push -u origin codex/maintenance-restart
+```
+
+- [ ] **Step 3: Open a draft pull request into master**
+
+Create a draft PR titled:
+
+```text
+[codex] restore Raven maintenance baseline
+```
+
+The PR body must summarize the dormant-project restart, stale documentation
+cleanup, Flyway password removal, JDK 26 compilation work, admin regression
+fix, GitHub Actions workflow, and local verification results.

--- a/docs/superpowers/specs/2026-06-01-maintenance-restart-design.md
+++ b/docs/superpowers/specs/2026-06-01-maintenance-restart-design.md
@@ -1,0 +1,127 @@
+# Raven Maintenance Restart Design
+
+## Context
+
+Raven is a multi-module Maven project for an instant messaging system. The
+default branch has not received a maintenance commit since 2020-03-15. This
+work restarts maintenance with a small, reviewable baseline rather than
+claiming that the project remained continuously active.
+
+The initial audit reproduced the following issues:
+
+- The README links to a deleted pressure-test report and advertises an old
+  public demo IP address with test account credentials.
+- The Flyway helper commits a local MySQL password in both configuration and
+  shell invocation.
+- Travis CI explicitly skips tests.
+- A clean Maven build on JDK 26 does not run the inherited Lombok 1.18.6
+  annotation processor.
+- `GroupServiceImpl` returns `ResultCode` for two methods whose interface and
+  controller contract require `Result`.
+- Four service POM files include an accidental `n` after the Docker image tag
+  configuration.
+
+## Goal
+
+Restore a credible maintenance baseline that is useful to contributors and
+maintainers:
+
+1. Describe the current project status honestly.
+2. Remove unsafe or stale public setup information.
+3. Make a clean build reproducible on a modern JDK.
+4. Fix the known admin service result-contract regression.
+5. Replace the placeholder CI configuration with real Maven verification.
+
+## Non-Goals
+
+This baseline does not upgrade Spring Boot, Spring Cloud, Netty, Kafka, Redis,
+MySQL, or the full dependency graph. Those upgrades need separate design and
+compatibility work because they can change runtime behavior across services.
+
+This baseline also does not claim production readiness. End-to-end deployment
+still depends on external infrastructure such as MySQL, Redis, Kafka, Nacos,
+ZooKeeper, and FastDFS.
+
+## Change Set
+
+### 1. Document The Maintenance Restart
+
+Update the README to:
+
+- State that the project is resuming maintenance after a dormant period.
+- Remove the stale demo endpoint and public test account block.
+- Remove the link to the deleted pressure-test report.
+- Add a module overview, local verification command, and links to maintenance
+  and contribution guidance.
+
+Add:
+
+- `MAINTENANCE.md` with the staged modernization roadmap and support policy.
+- `CONTRIBUTING.md` with a focused contribution workflow and verification
+  expectations.
+
+### 2. Remove Committed Local Database Credentials
+
+Update the Flyway helper to read local database settings from environment
+variables with development-friendly defaults that do not include a password.
+Keep the existing migration history intact so existing installations do not
+receive a destructive schema rewrite.
+
+Document that the bootstrap app secret committed in the historical seed
+migration must be rotated for any deployed environment.
+
+### 3. Restore Clean Modern-JDK Compilation
+
+Update Lombok to `1.18.46`, which adds JDK 26 support. Configure Maven
+explicitly so Lombok runs as an annotation processor on JDK 23 and newer.
+
+Fix the accidental Docker image tag suffix in the route, gateway, admin, and
+file-service POM files.
+
+### 4. Repair Group Membership Result Contracts
+
+Change `GroupServiceImpl.joinGroup` and `GroupServiceImpl.quitGroup` to return
+`Result`, matching the interface and controller boundary.
+
+Return `Result.failure(...)` for invalid member lists and use the
+`MemberNotInValidator` error code when a quit request includes a user who is
+not in the group.
+
+Add focused unit tests for these branches without requiring external
+infrastructure.
+
+### 5. Enable Real Continuous Integration
+
+Replace the Travis placeholder with a GitHub Actions Maven workflow. Run clean
+verification against Java 11 and Java 26 so the project retains its historical
+runtime baseline while also validating current maintainer tooling.
+
+## Commit Plan
+
+Keep each concern independently reviewable:
+
+1. `docs: define maintenance restart scope`
+2. `security: remove committed local database password`
+3. `build: restore clean compilation on modern JDKs`
+4. `fix(admin): align group membership service results`
+5. `ci: run Maven verification with GitHub Actions`
+
+## Verification
+
+Before completion:
+
+- Run `mvn clean verify` locally on JDK 26.
+- Confirm the new admin unit tests pass.
+- Confirm no tracked Flyway helper contains a local database password.
+- Inspect the final commit list and working tree.
+
+## Follow-Up Work
+
+After the baseline is green, track dependency modernization as separate work:
+
+- Upgrade Spring Boot and Spring Cloud in compatible stages.
+- Audit bundled Flyway command-line JARs and database drivers.
+- Review committed seed credentials and define a replacement bootstrap flow.
+- Add integration tests for MySQL, Redis, Kafka, Nacos, ZooKeeper, and FastDFS
+  boundaries.
+- Review release, security-reporting, and issue-triage processes.

--- a/flyway/conf/flyway.conf
+++ b/flyway/conf/flyway.conf
@@ -1,4 +1,3 @@
 #数据库配置
 flyway.url = jdbc:mysql://127.0.0.1:3306/imdb?useUnicode=true
 flyway.user = root
-flyway.password = 123456

--- a/flyway/flyway
+++ b/flyway/flyway
@@ -47,7 +47,7 @@ else
   JAVA_CMD=$JAVA_HOME/bin/java
  fi
 fi
-µ
+
 EXTRA_ARGS=
 CP="$INSTALLDIR/lib/*:$INSTALLDIR/drivers/*"
 

--- a/flyway/migrate.sh
+++ b/flyway/migrate.sh
@@ -1,7 +1,34 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-imdb}"
+MYSQL_USER="${MYSQL_USER:-root}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-}"
+
+if [[ ! "${MYSQL_DATABASE}" =~ ^[a-zA-Z0-9_]+$ ]]; then
+  echo "MYSQL_DATABASE must contain only letters, numbers, and underscores." >&2
+  exit 1
+fi
+
+mysql_args=(-u "${MYSQL_USER}" -h "${MYSQL_HOST}" -P "${MYSQL_PORT}")
+flyway_args=(
+  "-url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useUnicode=true"
+  "-user=${MYSQL_USER}"
+)
+
+if [[ -n "${MYSQL_PASSWORD}" ]]; then
+  mysql_args+=("-p${MYSQL_PASSWORD}")
+  flyway_args+=("-password=${MYSQL_PASSWORD}")
+fi
+
 # 创建数据库
-mysql -uroot -p123456 -h127.0.0.1 -P3306 -e "CREATE DATABASE IF NOT EXISTS imdb CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+mysql "${mysql_args[@]}" \
+  -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
 # 执行migrate
-bash flyway migrate
+"${SCRIPT_DIR}/flyway" "${flyway_args[@]}" migrate

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <version.commons.codec>1.12</version.commons.codec>
         <version.nacos.starter>0.2.1</version.nacos.starter>
         <version.nacos.alibaba.config>0.2.1.RELEASE</version.nacos.alibaba.config>
+        <lombok.version>1.18.46</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -103,4 +104,22 @@
             <version>${version.spring.boot}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/raven-admin/pom.xml
+++ b/raven-admin/pom.xml
@@ -110,7 +110,7 @@
                 <configuration>
                     <pullNewerImage>false</pullNewerImage>
                     <repository>${docker.image.prefix}/${project.build.finalName}</repository>
-                    <tag>latest</tag>n
+                    <tag>latest</tag>
                     <buildArgs>
                         <JAR_FILE>/target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/raven-admin/src/main/java/com/raven/admin/group/service/impl/GroupServiceImpl.java
+++ b/raven-admin/src/main/java/com/raven/admin/group/service/impl/GroupServiceImpl.java
@@ -74,10 +74,10 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    public ResultCode joinGroup(GroupReqParam reqParam) {
+    public Result joinGroup(GroupReqParam reqParam) {
         //params check.
         if (reqParam.getMembers() == null || reqParam.getMembers().size() == 0) {
-            return ResultCode.COMMON_INVALID_PARAMETER;
+            return Result.failure(ResultCode.COMMON_INVALID_PARAMETER);
         }
         if (!groupValidator.isValid(reqParam.getGroupId())) {
             return Result.failure(groupValidator.errorCode());
@@ -114,17 +114,17 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    public ResultCode quitGroup(GroupReqParam reqParam) {
+    public Result quitGroup(GroupReqParam reqParam) {
         //params check.
         if (reqParam.getMembers() == null || reqParam.getMembers().size() == 0) {
-            return ResultCode.COMMON_INVALID_PARAMETER;
+            return Result.failure(ResultCode.COMMON_INVALID_PARAMETER);
         }
 
         if (!groupValidator.isValid(reqParam.getGroupId())) {
             return Result.failure(groupValidator.errorCode());
         }
         if (!memberNotValidator.isValid(reqParam.getGroupId(), reqParam.getMembers())) {
-            return Result.failure(groupValidator.errorCode());
+            return Result.failure(memberNotValidator.errorCode());
         }
         reqParam.getMembers().forEach(uid -> {
             GroupMemberModel member = new GroupMemberModel();

--- a/raven-admin/src/test/java/com/raven/admin/group/service/impl/GroupServiceImplTest.java
+++ b/raven-admin/src/test/java/com/raven/admin/group/service/impl/GroupServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.raven.admin.group.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.raven.admin.group.bean.param.GroupReqParam;
+import com.raven.admin.group.validator.GroupValidator;
+import com.raven.admin.group.validator.MemberNotInValidator;
+import com.raven.common.result.Result;
+import com.raven.common.result.ResultCode;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GroupServiceImplTest {
+
+    @InjectMocks
+    private GroupServiceImpl service;
+
+    @Mock
+    private GroupValidator groupValidator;
+
+    @Mock
+    private MemberNotInValidator memberNotValidator;
+
+    @Test
+    public void joinGroupRejectsEmptyMemberList() {
+        GroupReqParam param = new GroupReqParam();
+        param.setMembers(Collections.emptyList());
+
+        Result result = service.joinGroup(param);
+
+        assertEquals(ResultCode.COMMON_INVALID_PARAMETER.getCode(), result.getCode().intValue());
+    }
+
+    @Test
+    public void quitGroupReportsMissingMember() {
+        GroupReqParam param = new GroupReqParam();
+        param.setGroupId("group-id");
+        param.setMembers(Collections.singletonList("missing-member"));
+        when(groupValidator.isValid("group-id")).thenReturn(true);
+        when(memberNotValidator.isValid("group-id", param.getMembers())).thenReturn(false);
+        when(memberNotValidator.errorCode()).thenReturn(ResultCode.GROUP_ERROR_MEMBER_NOT_IN);
+
+        Result result = service.quitGroup(param);
+
+        assertEquals(ResultCode.GROUP_ERROR_MEMBER_NOT_IN.getCode(), result.getCode().intValue());
+    }
+}

--- a/raven-file/pom.xml
+++ b/raven-file/pom.xml
@@ -84,7 +84,7 @@
                 <configuration>
                     <pullNewerImage>false</pullNewerImage>
                     <repository>${docker.image.prefix}/${project.build.finalName}</repository>
-                    <tag>latest</tag>n
+                    <tag>latest</tag>
                     <buildArgs>
                         <JAR_FILE>/target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/raven-gateway/pom.xml
+++ b/raven-gateway/pom.xml
@@ -94,7 +94,7 @@
                 <configuration>
                     <pullNewerImage>false</pullNewerImage>
                     <repository>${docker.image.prefix}/${project.build.finalName}</repository>
-                    <tag>latest</tag>n
+                    <tag>latest</tag>
                     <buildArgs>
                         <JAR_FILE>/target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/raven-route/pom.xml
+++ b/raven-route/pom.xml
@@ -93,7 +93,7 @@
                 <configuration>
                     <pullNewerImage>false</pullNewerImage>
                     <repository>${docker.image.prefix}/${project.build.finalName}</repository>
-                    <tag>latest</tag>n
+                    <tag>latest</tag>
                     <buildArgs>
                         <JAR_FILE>/target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>


### PR DESCRIPTION
## Summary

- document the June 2026 maintenance restart honestly and remove stale public demo details
- remove committed local Flyway password defaults and repair the migration helper
- restore clean modern-JDK Maven compilation with Lombok 1.18.46 and explicit annotation processing
- repair admin group membership result contracts with focused regression tests
- replace placeholder Travis CI with GitHub Actions verification on Java 11 and Java 26

## Root Cause

The dormant repository inherited Lombok 1.18.6 and relied on implicit annotation processor discovery. Modern JDKs no longer run classpath processors implicitly, so clean builds failed before reaching existing source defects. Once compilation was restored, `GroupServiceImpl` exposed stale `ResultCode` return types and an incorrect validator error mapping.

## Verification

- `mvn clean verify` on local JDK 26
- `bash -n flyway/migrate.sh flyway/flyway`
- `flyway/flyway -v`
- `git diff --check origin/master...HEAD`
- stale public demo and committed local password search returned no matches

## Follow-Up

The build remains intentionally scoped. Existing old dependency and assembly-plugin warnings are documented for staged modernization rather than bundled into this baseline PR.