### PR TITLE
fix(admin): single cached token per user (#86)

### DIFF
--- a/raven-admin/src/main/java/com/raven/admin/gateway/service/impl/GatewayServiceImpl.java
+++ b/raven-admin/src/main/java/com/raven/admin/gateway/service/impl/GatewayServiceImpl.java
@@ -6,6 +6,7 @@ import static com.raven.common.utils.Constants.CONFIG_TCP_PORT;
 import static com.raven.common.utils.Constants.CONFIG_WEBSOCKET_PORT;
 import static com.raven.common.utils.Constants.DEFAULT_SEPARATES_SIGN;
 import static com.raven.common.utils.Constants.TOKEN_CACHE_DURATION;
+import static com.raven.common.utils.Constants.USER_TOKEN;
 
 import com.raven.admin.gateway.bean.Token;
 import com.raven.admin.gateway.service.GatewayService;
@@ -64,14 +65,33 @@ public class GatewayServiceImpl implements GatewayService {
 
     @Override
     public Result getToken(String uid, String appKey) {
+        String key = appKey + DEFAULT_SEPARATES_SIGN + uid;
+        String userTokenKey = USER_TOKEN + key;
+        // Reuse the cached token so a user keeps exactly one valid token and we
+        // do not regenerate (and leave stale tokens behind) on every request.
+        String cachedToken = stringRedisTemplate.opsForValue().get(userTokenKey);
+        if (cachedToken != null && stringRedisTemplate.hasKey(cachedToken)) {
+            refreshTokenExpire(userTokenKey, cachedToken);
+            return Result.success(new OutTokenInfoParam(appKey, uid, cachedToken));
+        }
         try {
             String token = new Token(uid, appKey).getToken(appKey);
-            String key = appKey + DEFAULT_SEPARATES_SIGN + uid;
+            // Drop the previous token, if any, so only one token stays valid per user.
+            if (cachedToken != null) {
+                stringRedisTemplate.delete(cachedToken);
+            }
             stringRedisTemplate.opsForValue().set(token, key, TOKEN_CACHE_DURATION, TimeUnit.DAYS);
+            stringRedisTemplate.opsForValue()
+                .set(userTokenKey, token, TOKEN_CACHE_DURATION, TimeUnit.DAYS);
             return Result.success(new OutTokenInfoParam(appKey, uid, token));
         } catch (TokenException e) {
             return Result.failure(ResultCode.APP_ERROR_TOKEN_CREATE_ERROR);
         }
+    }
+
+    private void refreshTokenExpire(String userTokenKey, String token) {
+        stringRedisTemplate.expire(userTokenKey, TOKEN_CACHE_DURATION, TimeUnit.DAYS);
+        stringRedisTemplate.expire(token, TOKEN_CACHE_DURATION, TimeUnit.DAYS);
     }
 
     @Override

--- a/raven-admin/src/test/java/com/raven/admin/gateway/service/impl/GatewayServiceImplTest.java
+++ b/raven-admin/src/test/java/com/raven/admin/gateway/service/impl/GatewayServiceImplTest.java
@@ -1,0 +1,97 @@
+package com.raven.admin.gateway.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.raven.common.param.OutTokenInfoParam;
+import com.raven.common.result.Result;
+import com.raven.common.utils.Constants;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GatewayServiceImplTest {
+
+    private static final String UID = "user-1";
+    // DES requires an 8-byte key, so the app key (used as the cipher secret) must be >= 8 bytes.
+    private static final String APP_KEY = "appsecret";
+    private static final String USER_TOKEN_KEY = Constants.USER_TOKEN + APP_KEY + ":" + UID;
+
+    @InjectMocks
+    private GatewayServiceImpl service;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Before
+    public void setUp() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    public void getTokenReusesCachedTokenWithoutRegenerating() {
+        String cached = "cached-token";
+        when(valueOperations.get(USER_TOKEN_KEY)).thenReturn(cached);
+        when(stringRedisTemplate.hasKey(cached)).thenReturn(true);
+
+        Result result = service.getToken(UID, APP_KEY);
+
+        OutTokenInfoParam info = (OutTokenInfoParam) result.getData();
+        assertEquals("an existing token must be reused", cached, info.getToken());
+        // No new token is written when a valid one is cached.
+        verify(valueOperations, never()).set(any(), any(), anyLong(), any(TimeUnit.class));
+        // The single token's lifetime is refreshed instead.
+        verify(stringRedisTemplate).expire(eq(USER_TOKEN_KEY), anyLong(), any(TimeUnit.class));
+        verify(stringRedisTemplate).expire(eq(cached), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void getTokenCreatesAndIndexesTokenOnCacheMiss() {
+        when(valueOperations.get(USER_TOKEN_KEY)).thenReturn(null);
+
+        Result result = service.getToken(UID, APP_KEY);
+
+        OutTokenInfoParam info = (OutTokenInfoParam) result.getData();
+        assertNotNull(info.getToken());
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        // Both the token->user and user->token entries are written.
+        verify(valueOperations, times(2))
+            .set(keyCaptor.capture(), valueCaptor.capture(), anyLong(), any(TimeUnit.class));
+
+        int reverseIndex = keyCaptor.getAllValues().indexOf(USER_TOKEN_KEY);
+        assertEquals("reverse index must store the generated token",
+            info.getToken(), valueCaptor.getAllValues().get(reverseIndex));
+    }
+
+    @Test
+    public void getTokenDropsStaleTokenBeforeIssuingNewOne() {
+        String stale = "stale-token";
+        when(valueOperations.get(USER_TOKEN_KEY)).thenReturn(stale);
+        when(stringRedisTemplate.hasKey(stale)).thenReturn(false);
+
+        service.getToken(UID, APP_KEY);
+
+        // The previous token is removed so a user never accumulates multiple tokens.
+        verify(stringRedisTemplate).delete(stale);
+    }
+}


### PR DESCRIPTION
## Summary
Resolves #86 — a user should have exactly one token; today `getToken` mints a fresh token on every call and stores each one in Redis, so multiple tokens stay valid at once.

- Add a reverse index `token_<appKey>:<uid> -> token` alongside the existing `token -> <appKey>:<uid>` entry.
- On request, reuse the cached token when it is still present and just refresh both keys' TTL (no regeneration).
- When a token must be (re)generated, delete the previously cached token first, so a user never accumulates more than one valid token.

## Affected modules
- `raven-admin`

## How verified
- `mvn --batch-mode -pl raven-admin -am test` with a new `GatewayServiceImplTest` (Mockito): reuse-without-regeneration, create-and-index on cache miss, and stale-token cleanup — green.

## Runtime/config changes
None. Existing tokens keep working; the extra reverse-index key shares the same TTL (`TOKEN_CACHE_DURATION`).

Made with [Cursor](https://cursor.com)